### PR TITLE
Include age if provided within ical event description

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,12 +117,12 @@ class MyClient(discord.Client):
                 description = birthday.description.replace('\n', '')
                 if re.match("BIRTH_YEAR?=?[0-9]{4}$", description):
                     birth_year = int(birthday.description.split("=")[1])
-                    text = await self.attach_age_to_birthday(birth_year, text)
+                    text = self.attach_age_to_birthday(birth_year, text)
 
                 text += '\n'
                 await message.channel.send(text)
 
-    async def attach_age_to_birthday(self, birth_year, text):
+    def attach_age_to_birthday(self, birth_year, text):
         current_year = int(datetime.now().year)
         age = str(current_year - birth_year)
         text +=' and is turning **' + age + '** years old'

--- a/main.py
+++ b/main.py
@@ -110,10 +110,23 @@ class MyClient(discord.Client):
                 return
 
             text = "Here are the birthdays of this month: \n"
-            for birthday in self.a[month]:
-                text += "> " + birthday.name + " is on " + birthday.begin.format("MMMM DD") + "\n"
 
-            await message.channel.send(text)
+            for birthday in self.a[month]:
+                text = "> **" + birthday.name + "** is on **" + birthday.begin.format("MMMM DD") + "**"
     
+                description = birthday.description.replace('\n', '')
+                if re.match("BIRTH_YEAR?=?[0-9]{4}$", description):
+                    birth_year = int(birthday.description.split("=")[1])
+                    text = await self.attach_age_to_birthday(birth_year, text)
+
+                text += '\n'
+                await message.channel.send(text)
+
+    async def attach_age_to_birthday(self, birth_year, text):
+        current_year = int(datetime.now().year)
+        age = str(current_year - birth_year)
+        text +=' and is turning **' + age + '** years old'
+        return text
+
 client = MyClient()
 client.run(os.environ['ACCESS_TOKEN'])

--- a/main.py
+++ b/main.py
@@ -115,7 +115,7 @@ class MyClient(discord.Client):
                 text = "> **" + birthday.name + "** is on **" + birthday.begin.format("MMMM DD") + "**"
     
                 description = birthday.description.replace('\n', '')
-                if re.match("BIRTH_YEAR?=?[0-9]{4}$", description):
+                if re.match("BIRTH_YEAR?=?[1-9][0-9]{3}$", description):
                     birth_year = int(birthday.description.split("=")[1])
                     text = self.attach_age_to_birthday(birth_year, text)
 


### PR DESCRIPTION
### Feature Change
- If a `BIRTH_YEAR` is provided in the calendar event description, attach what age the person will be turning on their birthday
  - Calendar event description must reference a variable called `BIRTH_YEAR=xxxx`
- Outputs the following example *string* when displayed
  - `Brian's Birthday is on August 15 and is turning 22 years old`

### Tested Cases
**Attach age when...**
- Single birthday in the month with a valid `BIRTH_YEAR`
- Multiple birthdays in the month has valid `BIRTH_YEAR`'s

**Disregard age attachment when...**
- If **no** `BIRTH_YEAR` is provided **or** invalid variable name
- If duplicate *key*/*value* pairs exist
-  If `BIRTH_YEAR` value is invalid (*NaN*, **not** 4 digits, **not** in proper format)

### Notes
- No expected major breaking changes in this branch